### PR TITLE
Updated documentation to specify angle unit

### DIFF
--- a/src/base/matrix.rs
+++ b/src/base/matrix.rs
@@ -2131,7 +2131,7 @@ impl<T: Scalar + Field, S: RawStorage<T, U3>> Vector<T, U3, S> {
 }
 
 impl<T: SimdComplexField, R: Dim, C: Dim, S: Storage<T, R, C>> Matrix<T, R, C, S> {
-    /// The smallest angle between two vectors.
+    /// The smallest angle between two vectors. The value is expressed in radians.
     #[inline]
     #[must_use]
     pub fn angle<R2: Dim, C2: Dim, SB>(&self, other: &Matrix<T, R2, C2, SB>) -> T::SimdRealField

--- a/src/geometry/rotation_specialization.rs
+++ b/src/geometry/rotation_specialization.rs
@@ -414,6 +414,8 @@ where
     }
 
     /// Creates a new rotation from Euler angles.
+    /// 
+    /// Note that the angles are expressed in radians.
     ///
     /// The primitive rotations are applied in order: 1 roll − 2 pitch − 3 yaw.
     ///
@@ -937,6 +939,8 @@ impl<T: SimdRealField> Rotation3<T> {
     }
 
     /// Euler angles corresponding to this rotation from a rotation.
+    /// 
+    /// Note that the angles are expressed in radians.
     ///
     /// The angles are produced in the form (roll, pitch, yaw).
     ///


### PR DESCRIPTION
The PR aims to clarify which angle unit functions use, since there are some that use radians and others that use degrees. Based on the current documentation alone, a new user may not be certain what the correct input/output should look like. After researching the topic and looking into the function definitions, I added notes on what angle unit was used for each related function.

The modified files are:

`src/geometry/rotation_specialization.rs`
`src/base/matrix.rs`

Based on: https://github.com/dimforge/nalgebra/issues/1234